### PR TITLE
Lizard tongues are no longer annoying, two-tone scales, more character slots

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//doohickeys for savefiles
 	var/path
 	var/default_slot = 1 //Holder so it doesn't default to slot 1, rather the last one used
-	var/max_save_slots = 3
+	var/max_save_slots = 8
 
 	//non-preference stuff
 	var/muted = 0
@@ -99,7 +99,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			load_path(C.ckey)
 			unlock_content = !!C.IsByondMember()
 			if(unlock_content)
-				max_save_slots = 8
+				max_save_slots = 13
 
 	// give them default keybinds and update their movement keys
 	key_bindings = deep_copy_list(GLOB.default_hotkeys)

--- a/code/modules/client/preferences/species_features/basic.dm
+++ b/code/modules/client/preferences/species_features/basic.dm
@@ -37,14 +37,14 @@
 	var/obj/item/organ/eyes/eyes_organ = target.getorgan(/obj/item/organ/eyes)
 	if (!eyes_organ || !istype(eyes_organ))
 		return
-	
+
 	if (!initial(eyes_organ.eye_color_left))
 		eyes_organ.eye_color_left = value
 	eyes_organ.old_eye_color_left = value
 
 	if(hetero) // Don't override the snowflakes please
 		return
-	
+
 	if (!initial(eyes_organ.eye_color_right))
 		eyes_organ.eye_color_right = value
 	eyes_organ.old_eye_color_right = value
@@ -78,7 +78,7 @@
 	savefile_key = "facial_hair_color"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
-	relevant_species_trait = FACEHAIR
+	//relevant_species_trait = FACEHAIR
 
 /datum/preference/color/facial_hair_color/apply_to_human(mob/living/carbon/human/target, value)
 	target.facial_hair_color = value

--- a/code/modules/client/preferences/species_features/lizard.dm
+++ b/code/modules/client/preferences/species_features/lizard.dm
@@ -64,6 +64,13 @@
 /datum/preference/choiced/lizard_body_markings/apply_to_human(mob/living/carbon/human/target, value)
 	target.dna.features["body_markings"] = value
 
+/datum/preference/choiced/lizard_body_markings/compile_constant_data()
+	var/list/data = ..()
+
+	data[SUPPLEMENTAL_FEATURE_KEY] = "facial_hair_color"
+
+	return data
+
 /datum/preference/choiced/lizard_frills
 	savefile_key = "feature_lizard_frills"
 	savefile_identifier = PREFERENCE_CHARACTER
@@ -114,6 +121,13 @@
 
 /datum/preference/choiced/lizard_snout/apply_to_human(mob/living/carbon/human/target, value)
 	target.dna.features["snout"] = value
+
+/datum/preference/choiced/lizard_snout/compile_constant_data()
+	var/list/data = ..()
+
+	data[SUPPLEMENTAL_FEATURE_KEY] = "facial_hair_color"
+
+	return data
 
 /datum/preference/choiced/lizard_spines
 	savefile_key = "feature_lizard_spines"

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -1694,6 +1694,24 @@
 	icon_state = "lbelly"
 	gender_specific = 1
 
+/datum/sprite_accessory/body_markings/ltigercolor
+	name = "Light Tiger Body (Colored)"
+	icon_state = "ltiger"
+	gender_specific = 1
+	color_src = FACEHAIR
+
+/datum/sprite_accessory/body_markings/dtigercolor
+	name = "Dark Tiger Body (Colored)"
+	icon_state = "dtiger"
+	gender_specific = 1
+	color_src = FACEHAIR
+
+/datum/sprite_accessory/body_markings/lbellycolor
+	name = "Light Belly (Colored)"
+	icon_state = "lbelly"
+	gender_specific = 1
+	color_src = FACEHAIR
+
 /datum/sprite_accessory/tails
 	icon = 'icons/mob/mutant_bodyparts.dmi'
 	em_block = TRUE
@@ -1820,6 +1838,16 @@
 /datum/sprite_accessory/snouts/roundlight
 	name = "Round + Light"
 	icon_state = "roundlight"
+
+/datum/sprite_accessory/snouts/sharpcolor
+	name = "Sharp + Colored"
+	icon_state = "sharplight"
+	color_src = FACEHAIR
+
+/datum/sprite_accessory/snouts/roundcolor
+	name = "Round + Colored"
+	icon_state = "roundlight"
+	color_src = FACEHAIR
 
 /datum/sprite_accessory/horns
 	icon = 'icons/mob/mutant_bodyparts.dmi'

--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -207,6 +207,7 @@
 	external_bodytypes = BODYTYPE_SNOUTED
 
 	dna_block = DNA_SNOUT_BLOCK
+	overrides_color = TRUE
 
 /obj/item/organ/external/snout/can_draw_on_bodypart(mob/living/carbon/human/human)
 	if(!(human.wear_mask?.flags_inv & HIDESNOUT) && !(human.head?.flags_inv & HIDESNOUT))
@@ -215,6 +216,15 @@
 
 /obj/item/organ/external/snout/get_global_feature_list()
 	return GLOB.snouts_list
+
+/obj/item/organ/external/snout/override_color(rgb_value)
+	if(!sprite_datum)
+		return rgb_value
+	if(sprite_datum.color_src == FACEHAIR)
+		if(ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			return H.facial_hair_color
+	return rgb_value
 
 ///A moth's antennae
 /obj/item/organ/external/antennae

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -82,7 +82,7 @@
 	icon_state = "tonguelizard"
 	say_mod = "hisses"
 	taste_sensitivity = 10 // combined nose + tongue, extra sensitive
-	modifies_speech = TRUE
+	modifies_speech = FALSE
 	languages_native = list(/datum/language/draconic)
 
 /obj/item/organ/tongue/lizard/modify_speech(datum/source, list/speech_args)


### PR DESCRIPTION
- Lizard tongues no longer modify speech. If you want to hiss you'll have to commit to the bit and do it manually.
- This adds new snout and body marking options for lizardpeople, which use the facial hair color instead of the normal mutant color, allowing for more variety in customization.
- Character slots have been increased from 3 to 8, or from 8 to (Space Station) 13 for BYOND members.