### PR TITLE
Slows down organ decay to make it fit lowpop better.

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -14,7 +14,8 @@
 	attack_verb_simple = list("attack", "slap", "whack")
 
 	///The brain's organ variables are significantly more different than the other organs, with half the decay rate for balance reasons, and twice the maxHealth
-	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes of decaying to result in a fully damaged brain, since a fast decay rate would be unfun gameplay-wise
+	//decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes of decaying to result in a fully damaged brain, since a fast decay rate would be unfun gameplay-wise
+	decay_factor = STANDARD_ORGAN_DECAY * 0.25 //1 hour
 
 	maxHealth = BRAIN_DAMAGE_DEATH
 	low_threshold = 45

--- a/code/modules/surgery/organs/appendix.dm
+++ b/code/modules/surgery/organs/appendix.dm
@@ -12,7 +12,8 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/toxin/bad_food = 5)
 	grind_results = list(/datum/reagent/toxin/bad_food = 5)
 	healing_factor = STANDARD_ORGAN_HEALING
-	decay_factor = STANDARD_ORGAN_DECAY
+	//decay_factor =  STANDARD_ORGAN_DECAY * 0.25
+	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
 
 	now_failing = "<span class='warning'>An explosion of pain erupts in your lower right abdomen!</span>"
 	now_fixed = "<span class='info'>The pain in your abdomen has subsided.</span>"

--- a/code/modules/surgery/organs/appendix.dm
+++ b/code/modules/surgery/organs/appendix.dm
@@ -12,7 +12,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/toxin/bad_food = 5)
 	grind_results = list(/datum/reagent/toxin/bad_food = 5)
 	healing_factor = STANDARD_ORGAN_HEALING
-	//decay_factor =  STANDARD_ORGAN_DECAY * 0.25
+	//decay_factor =  STANDARD_ORGAN_DECAY
 	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
 
 	now_failing = "<span class='warning'>An explosion of pain erupts in your lower right abdomen!</span>"

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -8,7 +8,8 @@
 	gender = PLURAL
 
 	healing_factor = STANDARD_ORGAN_HEALING
-	decay_factor = STANDARD_ORGAN_DECAY
+	//decay_factor = STANDARD_ORGAN_DECAY
+	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
 
 	low_threshold_passed = "<span class='info'>Your ears begin to resonate with an internal ring sometimes.</span>"
 	now_failing = "<span class='warning'>You are unable to hear at all!</span>"

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -8,7 +8,8 @@
 	gender = PLURAL
 
 	healing_factor = STANDARD_ORGAN_HEALING
-	decay_factor = STANDARD_ORGAN_DECAY
+	//decay_factor = STANDARD_ORGAN_DECAY
+	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
 	maxHealth = 0.5 * STANDARD_ORGAN_THRESHOLD //half the normal health max since we go blind at 30, a permanent blindness at 50 therefore makes sense unless medicine is administered
 	high_threshold = 0.3 * STANDARD_ORGAN_THRESHOLD //threshold at 30
 	low_threshold = 0.2 * STANDARD_ORGAN_THRESHOLD //threshold at 20

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -9,7 +9,7 @@
 
 	healing_factor = STANDARD_ORGAN_HEALING
 	//decay_factor = 2.5 * STANDARD_ORGAN_DECAY //designed to fail around 6 minutes after death
-	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
+	decay_factor = STANDARD_ORGAN_DECAY * 0.75 //20 minutes
 	
 	low_threshold_passed = "<span class='info'>Prickles of pain appear then die out from within your chest...</span>"
 	high_threshold_passed = "<span class='warning'>Something inside your chest hurts, and the pain isn't subsiding. You notice yourself breathing far faster than before.</span>"

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -8,8 +8,9 @@
 	slot = ORGAN_SLOT_HEART
 
 	healing_factor = STANDARD_ORGAN_HEALING
-	decay_factor = 2.5 * STANDARD_ORGAN_DECAY //designed to fail around 6 minutes after death
-
+	//decay_factor = 2.5 * STANDARD_ORGAN_DECAY //designed to fail around 6 minutes after death
+	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
+	
 	low_threshold_passed = "<span class='info'>Prickles of pain appear then die out from within your chest...</span>"
 	high_threshold_passed = "<span class='warning'>Something inside your chest hurts, and the pain isn't subsiding. You notice yourself breathing far faster than before.</span>"
 	now_fixed = "<span class='info'>Your heart begins to beat again.</span>"

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -12,8 +12,9 @@
 
 	maxHealth = STANDARD_ORGAN_THRESHOLD
 	healing_factor = STANDARD_ORGAN_HEALING
-	decay_factor = STANDARD_ORGAN_DECAY // smack in the middle of decay times
-
+	//decay_factor = STANDARD_ORGAN_DECAY // smack in the middle of decay times
+	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
+	
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/iron = 5)
 	grind_results = list(/datum/reagent/consumable/nutriment/peptides = 5)
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -10,8 +10,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 
 	healing_factor = STANDARD_ORGAN_HEALING
-	decay_factor = STANDARD_ORGAN_DECAY * 0.9 // fails around 16.5 minutes, lungs are one of the last organs to die (of the ones we have)
-
+	//decay_factor = STANDARD_ORGAN_DECAY * 0.9 // fails around 16.5 minutes, lungs are one of the last organs to die (of the ones we have)
+	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
+	
 	low_threshold_passed = "<span class='warning'>You feel short of breath.</span>"
 	high_threshold_passed = "<span class='warning'>You feel some sort of constriction around your chest as your breathing becomes shallow and rapid.</span>"
 	now_fixed = "<span class='warning'>Your lungs seem to once again be able to hold air.</span>"

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -11,7 +11,7 @@
 
 	healing_factor = STANDARD_ORGAN_HEALING
 	//decay_factor = STANDARD_ORGAN_DECAY * 0.9 // fails around 16.5 minutes, lungs are one of the last organs to die (of the ones we have)
-	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
+	decay_factor = STANDARD_ORGAN_DECAY * 0.42 //35 minutes
 	
 	low_threshold_passed = "<span class='warning'>You feel short of breath.</span>"
 	high_threshold_passed = "<span class='warning'>You feel some sort of constriction around your chest as your breathing becomes shallow and rapid.</span>"

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -14,7 +14,7 @@
 
 	healing_factor = STANDARD_ORGAN_HEALING
 	//decay_factor = STANDARD_ORGAN_DECAY * 1.15 // ~13 minutes, the stomach is one of the first organs to die
-	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
+	decay_factor = STANDARD_ORGAN_DECAY * 0.6 //25 minutes
 	
 	low_threshold_passed = "<span class='info'>Your stomach flashes with pain before subsiding. Food doesn't seem like a good idea right now.</span>"
 	high_threshold_passed = "<span class='warning'>Your stomach flares up with constant pain- you can hardly stomach the idea of food right now!</span>"

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -13,8 +13,9 @@
 	desc = "Onaka ga suite imasu."
 
 	healing_factor = STANDARD_ORGAN_HEALING
-	decay_factor = STANDARD_ORGAN_DECAY * 1.15 // ~13 minutes, the stomach is one of the first organs to die
-
+	//decay_factor = STANDARD_ORGAN_DECAY * 1.15 // ~13 minutes, the stomach is one of the first organs to die
+	decay_factor = STANDARD_ORGAN_DECAY * 0.5 //30 minutes
+	
 	low_threshold_passed = "<span class='info'>Your stomach flashes with pain before subsiding. Food doesn't seem like a good idea right now.</span>"
 	high_threshold_passed = "<span class='warning'>Your stomach flares up with constant pain- you can hardly stomach the idea of food right now!</span>"
 	high_threshold_cleared = "<span class='info'>The pain in your stomach dies down for now, but food still seems unappealing.</span>"


### PR DESCRIPTION
By popular request, slowed down organ decay on death.

It will take 15 minutes until organs reach the point where they are damaged enough to warrant a surgery for healing. It will take 30 minutes when they fail, and have to be replaced.

Brain decay had 30 minutes until total braindeath, this has been changed to 1 hour to lessen the amount of traumas you get.

The organs used to have a whimsical fail order, due to different failing speed, so I am not against figuring out some speed to stagger them a lil' bit, so you don't have to do all of the surgeries, if we can figure out a proper duration for them. 

Just for reference, the way organ decay is calculated, is the organ's decay factory times seconds since the last organ decay moment.

EDIT: The organs are staggered now. Hearts ruin at 20 mins, stomachs at 25 and lungs at 35.

